### PR TITLE
User roles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.0</version>
+		<version>3.4.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.G15.musicplatform</groupId>

--- a/src/main/java/com/G15/musicplatform/collab_music_platform/controller/ProjectController.java
+++ b/src/main/java/com/G15/musicplatform/collab_music_platform/controller/ProjectController.java
@@ -2,6 +2,7 @@ package com.G15.musicplatform.collab_music_platform.controller;
 
 import com.G15.musicplatform.collab_music_platform.model.Project;
 import com.G15.musicplatform.collab_music_platform.model.ProjectFile;
+import com.G15.musicplatform.collab_music_platform.model.User;
 import com.G15.musicplatform.collab_music_platform.repository.ProjectFileRepository;
 import com.G15.musicplatform.collab_music_platform.repository.ProjectRepository;
 import com.G15.musicplatform.collab_music_platform.service.ProjectService;
@@ -13,7 +14,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/projects")
@@ -31,6 +35,9 @@ public class ProjectController {
     @Value("${upload.path}")
     private String uploadDir;
 
+    /**
+     * Create a project. The user is later assigned as PROJECT_OWNER in the service layer.
+     */
     @PostMapping
     public ResponseEntity<String> createProject(
             @RequestParam("name") String name,
@@ -45,16 +52,24 @@ public class ProjectController {
         return ResponseEntity.ok(projects);
     }
 
+    /**
+     * Upload file: owners & contributors may do so (if you want a role check, add one in service).
+     * For simplicity, we won't do a check here, but you can easily add one if needed.
+     */
     @PostMapping("/{projectId}/upload")
     public ResponseEntity<String> uploadFileToProject(
             @PathVariable Long projectId,
-            @RequestParam("file") MultipartFile file) {
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("username") String username) {
 
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new RuntimeException("Project not found"));
 
+        // If you want to enforce role check for upload, do it in ProjectService.
+        // E.g., projectService.uploadFile(...)
+
         try {
-            // Save file to upload directory
+            // Save file physically
             String filePath = uploadDir + "/" + file.getOriginalFilename();
             File destination = new File(filePath);
             if (!destination.getParentFile().exists()) {
@@ -62,7 +77,7 @@ public class ProjectController {
             }
             file.transferTo(destination);
 
-            // Save file metadata
+            // Save metadata
             ProjectFile projectFile = new ProjectFile();
             projectFile.setFileName(file.getOriginalFilename());
             projectFile.setFilePath(filePath);
@@ -83,20 +98,80 @@ public class ProjectController {
         return ResponseEntity.ok(project.getProjectFiles());
     }
 
-    // NEW: Delete Project Endpoint
+    /**
+     * Delete an entire project, only allowed for PROJECT_OWNER
+     */
     @DeleteMapping("/{projectId}")
-    public ResponseEntity<String> deleteProject(@PathVariable Long projectId) {
-        projectService.deleteProject(projectId);
+    public ResponseEntity<String> deleteProject(
+            @PathVariable Long projectId,
+            @RequestParam("username") String username) {
+        projectService.deleteProject(projectId, username);
         return ResponseEntity.ok("Project deleted successfully.");
     }
 
-    // NEW: Delete File Endpoint
+    /**
+     * Delete a file within a project, allowed for PROJECT_OWNER and CONTRIBUTOR
+     */
     @DeleteMapping("/{projectId}/files/{fileId}")
     public ResponseEntity<String> deleteFileFromProject(
             @PathVariable Long projectId,
-            @PathVariable Long fileId) {
-        projectService.deleteFileFromProject(projectId, fileId);
+            @PathVariable Long fileId,
+            @RequestParam("username") String username) {
+        projectService.deleteFileFromProject(projectId, fileId, username);
         return ResponseEntity.ok("File deleted successfully.");
+    }
+
+    /**
+     * Assign a role to another user. Only PROJECT_OWNER can do so.
+     * e.g. /api/projects/5/assign-role?userId=10&role=CONTRIBUTOR&username=alice
+     */
+    @PostMapping("/{projectId}/assign-role")
+    public ResponseEntity<String> assignRole(
+            @PathVariable Long projectId,
+            @RequestParam Long userId,
+            @RequestParam String role,
+            @RequestParam("username") String requestingUser) {
+        projectService.assignRole(projectId, userId, role, requestingUser);
+        return ResponseEntity.ok("Role assigned successfully.");
+    }
+
+    /**
+     * Revoke an existing role from a user. Only PROJECT_OWNER can do so.
+     */
+    @PostMapping("/{projectId}/revoke-role")
+    public ResponseEntity<String> revokeRole(
+            @PathVariable Long projectId,
+            @RequestParam Long userId,
+            @RequestParam("username") String requestingUser) {
+        projectService.revokeRole(projectId, userId, requestingUser);
+        return ResponseEntity.ok("Role revoked successfully.");
+    }
+
+    /**
+     * Get the role for a particular user in a project.
+     */
+    @GetMapping("/{projectId}/role")
+    public ResponseEntity<String> getRoleForUser(
+            @PathVariable Long projectId,
+            @RequestParam String username) {
+        String role = projectService.getRoleForUserByUsername(projectId, username);
+        return ResponseEntity.ok(role);
+    }
+
+    @GetMapping("/{projectId}/users")
+    public List<Map<String, String>> getProjectUsers(@PathVariable Long projectId) {
+        Project project = projectRepository.findById(projectId)
+            .orElseThrow(() -> new RuntimeException("Project not found"));
+
+        // Build a simple list of { username: "bob", role: "CONTRIBUTOR" } objects
+        List<Map<String, String>> userList = new ArrayList<>();
+        for (Map.Entry<User, String> entry : project.getUserRoles().entrySet()) {
+            Map<String, String> u = new HashMap<>();
+            u.put("username", entry.getKey().getUsername());
+            u.put("role", entry.getValue());
+            userList.add(u);
+        }
+        return userList;
     }
 
 }

--- a/src/main/java/com/G15/musicplatform/collab_music_platform/controller/UserController.java
+++ b/src/main/java/com/G15/musicplatform/collab_music_platform/controller/UserController.java
@@ -11,7 +11,10 @@ import jakarta.validation.Valid;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -148,6 +151,23 @@ public class UserController {
             return ResponseEntity.ok(files);
         } catch (Exception e) {
             return ResponseEntity.status(500).body("Failed to fetch files: " + e.getMessage());
+        }
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> searchUserByUsername(@RequestParam("username") String username) {
+        Optional<User> userOpt = userRepository.findByUsername(username);
+        if (userOpt.isPresent()) {
+            // Return some minimal user info (like ID, username)
+            User user = userOpt.get();
+            Map<String, Object> userData = new HashMap<>();
+            userData.put("id", user.getId());
+            userData.put("username", user.getUsername());
+            return ResponseEntity.ok(userData);
+        } else {
+            // Return 404 or 200 with a message, up to you
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body("No such user found.");
         }
     }
 

--- a/src/main/java/com/G15/musicplatform/collab_music_platform/model/Project.java
+++ b/src/main/java/com/G15/musicplatform/collab_music_platform/model/Project.java
@@ -2,7 +2,9 @@ package com.G15.musicplatform.collab_music_platform.model;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Entity
 @Table(name = "projects")
@@ -13,15 +15,21 @@ public class Project {
     private Long id;
 
     private String name;
-
     private LocalDateTime createdAt = LocalDateTime.now();
 
+    // "Owner" or "Creator"
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<ProjectFile> projectFiles;
+
+    @ElementCollection
+    @CollectionTable(name = "project_roles", joinColumns = @JoinColumn(name = "project_id"))
+    @MapKeyJoinColumn(name = "user_id")
+    @Column(name = "role")
+    private Map<User, String> userRoles = new HashMap<>();
 
     // Getters and Setters
     public Long getId() {
@@ -58,5 +66,13 @@ public class Project {
 
     public List<ProjectFile> getProjectFiles() {
         return projectFiles;
+    }
+
+    public void setUserRoles(Map<User, String> userRoles) {
+        this.userRoles = userRoles;
+    }
+
+    public Map<User, String> getUserRoles() {
+        return userRoles;
     }
 }

--- a/src/main/java/com/G15/musicplatform/collab_music_platform/model/RoleEnum.java
+++ b/src/main/java/com/G15/musicplatform/collab_music_platform/model/RoleEnum.java
@@ -1,0 +1,7 @@
+package com.G15.musicplatform.collab_music_platform.model;
+
+public enum RoleEnum {
+    PROJECT_OWNER,
+    CONTRIBUTOR,
+    REVIEWER;
+}

--- a/src/main/java/com/G15/musicplatform/collab_music_platform/repository/ProjectRepository.java
+++ b/src/main/java/com/G15/musicplatform/collab_music_platform/repository/ProjectRepository.java
@@ -3,9 +3,17 @@ package com.G15.musicplatform.collab_music_platform.repository;
 import com.G15.musicplatform.collab_music_platform.model.Project;
 import com.G15.musicplatform.collab_music_platform.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByUser(User user);
+
+    // NEW: find all projects where the given user is either the .user (creator)
+    // or appears in the userRoles map for that project.
+    @Query("SELECT p FROM Project p LEFT JOIN p.userRoles roles " +
+           "WHERE key(roles) = :user OR p.user = :user")
+    List<Project> findProjectsWhereUserHasRoleOrIsOwner(@Param("user") User user);
 }

--- a/src/main/java/com/G15/musicplatform/collab_music_platform/service/ProjectService.java
+++ b/src/main/java/com/G15/musicplatform/collab_music_platform/service/ProjectService.java
@@ -52,9 +52,9 @@ public class ProjectService {
     public List<Project> getAllProjectsForUser(String username) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new RuntimeException("User not found"));
-        // If you only want to show projects that the user is "involved in" (role or owner),
-        // you could do a more custom query. But right now, this just returns projects by .getUser() match.
-        return projectRepository.findByUser(user);
+    
+        // Use the new custom query that returns projects either owned or having user in the roles map
+        return projectRepository.findProjectsWhereUserHasRoleOrIsOwner(user);
     }
 
     /**

--- a/src/main/java/com/G15/musicplatform/collab_music_platform/service/ProjectService.java
+++ b/src/main/java/com/G15/musicplatform/collab_music_platform/service/ProjectService.java
@@ -28,42 +28,134 @@ public class ProjectService {
     @Value("${upload.path}")
     private String uploadDir;
 
+    /**
+     * Allows any user to create a project (no prior role needed).
+     * Immediately afterward, that user is assigned the PROJECT_OWNER role for that project.
+     */
     public Project createProject(String name, String username) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
+        // Step 1: Create and save the project
         Project project = new Project();
         project.setName(name);
-        project.setUser(user);
+        project.setUser(user);  // The "owning user" field if you still want to track who 'created' it
+        Project savedProject = projectRepository.save(project);
 
-        return projectRepository.save(project);
+        // Step 2: Now assign the user the PROJECT_OWNER role for this project
+        savedProject.getUserRoles().put(user, "PROJECT_OWNER");
+        savedProject = projectRepository.save(savedProject);
+
+        return savedProject;
     }
 
     public List<Project> getAllProjectsForUser(String username) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new RuntimeException("User not found"));
+        // If you only want to show projects that the user is "involved in" (role or owner),
+        // you could do a more custom query. But right now, this just returns projects by .getUser() match.
         return projectRepository.findByUser(user);
     }
 
-    public void deleteProject(Long projectId) {
+    /**
+     * For assigning a role, only a PROJECT_OWNER (of that project) can do it.
+     */
+    public void assignRole(Long projectId, Long targetUserId, String newRole, String requestingUsername) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new RuntimeException("Project not found"));
 
-        // Delete files from the filesystem
+        User requestingUser = userRepository.findByUsername(requestingUsername)
+                .orElseThrow(() -> new RuntimeException("Requesting user not found"));
+        String requestingUserRole = project.getUserRoles().getOrDefault(requestingUser, "NONE");
+
+        // Only PROJECT_OWNER can assign roles
+        if (!"PROJECT_OWNER".equals(requestingUserRole)) {
+            throw new RuntimeException("Only the project owner can assign roles.");
+        }
+
+        // Now assign the role to the target user
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new RuntimeException("Target user not found"));
+
+        project.getUserRoles().put(targetUser, newRole);
+        projectRepository.save(project);
+    }
+
+    /**
+     * For revoking a role, only a PROJECT_OWNER can do it.
+     */
+    public void revokeRole(Long projectId, Long targetUserId, String requestingUsername) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("Project not found"));
+
+        User requestingUser = userRepository.findByUsername(requestingUsername)
+                .orElseThrow(() -> new RuntimeException("Requesting user not found"));
+        String requestingUserRole = project.getUserRoles().getOrDefault(requestingUser, "NONE");
+
+        // Only PROJECT_OWNER can revoke roles
+        if (!"PROJECT_OWNER".equals(requestingUserRole)) {
+            throw new RuntimeException("Only the project owner can revoke roles.");
+        }
+
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new RuntimeException("Target user not found"));
+
+        project.getUserRoles().remove(targetUser);
+        projectRepository.save(project);
+    }
+
+    public String getRoleForUser(Long projectId, Long userId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("Project not found"));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return project.getUserRoles().getOrDefault(user, "NONE");
+    }
+
+    /**
+     * Deletes an entire project. Only the PROJECT_OWNER can do this.
+     */
+    public void deleteProject(Long projectId, String requestingUsername) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("Project not found"));
+
+        User requestingUser = userRepository.findByUsername(requestingUsername)
+                .orElseThrow(() -> new RuntimeException("Requesting user not found"));
+        String requestingUserRole = project.getUserRoles().getOrDefault(requestingUser, "NONE");
+
+        if (!"PROJECT_OWNER".equals(requestingUserRole)) {
+            throw new RuntimeException("Only the project owner can delete this project.");
+        }
+
+        // Delete files from the filesystem first
         for (ProjectFile file : project.getProjectFiles()) {
             deleteFileFromSystem(file.getFilePath());
         }
 
-        // The cascade might handle this, but to be explicit:
         projectFileRepository.deleteAll(project.getProjectFiles());
 
-        // Delete the project
+        // Finally, delete the project
         projectRepository.delete(project);
     }
 
-    public void deleteFileFromProject(Long projectId, Long fileId) {
+    /**
+     * Deletes a file from a project. Owners and Contributors can do this; Reviewers cannot.
+     */
+    public void deleteFileFromProject(Long projectId, Long fileId, String requestingUsername) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new RuntimeException("Project not found"));
+
+        // Check the requestor's role
+        User requestingUser = userRepository.findByUsername(requestingUsername)
+                .orElseThrow(() -> new RuntimeException("Requesting user not found"));
+        String requestingUserRole = project.getUserRoles().getOrDefault(requestingUser, "NONE");
+
+        // Only owners and contributors can delete files
+        if (!("PROJECT_OWNER".equals(requestingUserRole) || "CONTRIBUTOR".equals(requestingUserRole))) {
+            throw new RuntimeException("You do not have permission to delete files in this project.");
+        }
 
         ProjectFile file = projectFileRepository.findById(fileId)
                 .orElseThrow(() -> new RuntimeException("File not found"));
@@ -73,10 +165,10 @@ public class ProjectService {
             throw new RuntimeException("File does not belong to the specified project.");
         }
 
-        // Delete file from filesystem
+        // Delete from filesystem
         deleteFileFromSystem(file.getFilePath());
 
-        // Delete file record from DB
+        // Delete record from DB
         projectFileRepository.delete(file);
     }
 
@@ -88,4 +180,16 @@ public class ProjectService {
             }
         }
     }
+
+    // In ProjectService.java
+    public String getRoleForUserByUsername(Long projectId, String username) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("Project not found"));
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        // Return the role from projectRoles map or "NONE" if missing
+        return project.getUserRoles().getOrDefault(user, "NONE");
+    }
+
 }

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -185,3 +185,32 @@ body.dashboard-body {
 
 /* Make sure prompt-driven alert boxes aren't influenced by CSS */
 /* You can style the prompt differently or use a custom modal for better UX */
+
+/* Adjust the container that holds Upload, Files, and Users sections side by side */
+.middle-panels-wrapper {
+  flex: 2; /* Takes up more space than the project list sidebar */
+  display: flex;
+  gap: 20px;
+}
+
+/* Each panel in the middle can share some common box styling */
+.upload-container,
+.files-section,
+.users-section {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  flex: 1; /* Make each panel flex evenly */
+  min-height: 200px; /* Just to give each some visible space */
+}
+
+/* For the user list items */
+#userList {
+  list-style: none;
+  padding: 0;
+}
+
+#userList li {
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+}

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -21,8 +21,8 @@
         <button id="createProjectBtn">Create New Project</button>
       </div>
 
-      <!-- Middle Upload and Files control -->
-      <div class="upload-section-wrapper">
+      <!-- Middle Upload and Files control (wrap them in a flex/grid container) -->
+      <div class="middle-panels-wrapper">
         <!-- Upload Section -->
         <div class="upload-container">
           <h2>Upload Files</h2>
@@ -37,6 +37,16 @@
           <h2>Project Files</h2>
           <button id="showFilesBtn">Show Files</button>
           <ul id="fileList"></ul>
+        </div>
+
+        <!-- Users Section -->
+        <div class="users-section">
+          <h2>Project Users</h2>
+          <ul id="userList"></ul>
+
+          <!-- Buttons only project owner should see -->
+          <button id="addUserBtn" style="display: none">Add User</button>
+          <button id="removeUserBtn" style="display: none">Remove User</button>
         </div>
       </div>
     </div>

--- a/src/main/resources/static/js/dashboard.js
+++ b/src/main/resources/static/js/dashboard.js
@@ -6,6 +6,10 @@ document.addEventListener("DOMContentLoaded", () => {
   const fileInput = document.getElementById("fileInput");
   const fileList = document.getElementById("fileList");
   const showFilesBtn = document.getElementById("showFilesBtn");
+  const userList = document.getElementById("userList");
+  // NEW:
+  const addUserBtn = document.getElementById("addUserBtn");
+  const removeUserBtn = document.getElementById("removeUserBtn");
 
   let currentProjectId = null;
 
@@ -15,12 +19,39 @@ document.addEventListener("DOMContentLoaded", () => {
     alert("Please log in first!");
     window.location.href = "index.html";
   }
-
   document.getElementById(
     "welcomeMessage"
-  ).textContent = `Welcome, ${username}!`;
+  ).textContent = `Welcome, ${username}!!!`;
 
-  // Fetch and display projects
+  /**
+   * Check if the logged-in user is the PROJECT_OWNER for the current project.
+   * If yes, show the Add/Remove user buttons; if no, hide them.
+   */
+  const checkIfUserIsOwner = async (projectId, username) => {
+    try {
+      // GET /api/projects/:projectId/role?userId=xxxx
+      const response = await fetch(
+        `/api/projects/${projectId}/role?username=${username}`
+      );
+      const role = await response.text(); // e.g., "PROJECT_OWNER", "CONTRIBUTOR", etc.
+
+      if (role === "PROJECT_OWNER") {
+        addUserBtn.style.display = "inline-block";
+        removeUserBtn.style.display = "inline-block";
+      } else {
+        addUserBtn.style.display = "none";
+        removeUserBtn.style.display = "none";
+      }
+    } catch (error) {
+      console.error("Error checking user role:", error);
+      addUserBtn.style.display = "none";
+      removeUserBtn.style.display = "none";
+    }
+  };
+
+  /**
+   * Fetch and display projects for the logged-in user.
+   */
   const fetchProjects = async () => {
     try {
       const response = await fetch(`/api/projects?username=${username}`);
@@ -40,14 +71,17 @@ document.addEventListener("DOMContentLoaded", () => {
           // Delete project button
           const deleteProjectBtn = document.createElement("button");
           deleteProjectBtn.textContent = "Delete";
-          deleteProjectBtn.style.background = "#dc3545";
-          deleteProjectBtn.style.color = "#fff";
-          deleteProjectBtn.style.marginLeft = "10px";
-          deleteProjectBtn.style.border = "none";
-          deleteProjectBtn.style.padding = "5px 10px";
-          deleteProjectBtn.style.borderRadius = "4px";
-          deleteProjectBtn.style.cursor = "pointer";
+          Object.assign(deleteProjectBtn.style, {
+            background: "#dc3545",
+            color: "#fff",
+            marginLeft: "10px",
+            border: "none",
+            padding: "5px 10px",
+            borderRadius: "4px",
+            cursor: "pointer",
+          });
 
+          // Delete project event
           deleteProjectBtn.addEventListener("click", async (e) => {
             e.stopPropagation(); // Prevent triggering project selection
             const confirmDelete = confirm(
@@ -56,9 +90,11 @@ document.addEventListener("DOMContentLoaded", () => {
             if (!confirmDelete) return;
 
             try {
-              const delResponse = await fetch(`/api/projects/${project.id}`, {
-                method: "DELETE",
-              });
+              // Must pass username => role check in backend
+              const delResponse = await fetch(
+                `/api/projects/${project.id}?username=${username}`,
+                { method: "DELETE" }
+              );
               if (delResponse.ok) {
                 alert("Project deleted successfully.");
                 fetchProjects(); // Refresh project list
@@ -66,18 +102,26 @@ document.addEventListener("DOMContentLoaded", () => {
                   currentProjectId = null;
                   fileList.innerHTML = "";
                   uploadSection.style.display = "none";
+                  userList.innerHTML = "";
                 }
               } else {
-                alert("Failed to delete project.");
+                const errorMsg = await delResponse.text();
+                alert("Failed to delete project: " + errorMsg);
               }
             } catch (err) {
               console.error("Error deleting project:", err);
             }
           });
 
-          listItem.addEventListener("click", () => {
+          // Clicking the list item => select this project
+          listItem.addEventListener("click", async () => {
             currentProjectId = project.id;
             uploadSection.style.display = "block";
+
+            // 1) Fetch the user list
+            await fetchProjectUsers(currentProjectId);
+            // 2) Check if this logged-in user is the PROJECT_OWNER
+            await checkIfUserIsOwner(currentProjectId, username);
           });
 
           listItem.appendChild(deleteProjectBtn);
@@ -92,7 +136,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   };
 
-  // Fetch and display files for a specific project
+  /**
+   * Fetch and display files for a specific project.
+   */
   const fetchProjectFiles = async (projectId) => {
     try {
       const response = await fetch(`/api/projects/${projectId}/files`);
@@ -113,12 +159,14 @@ document.addEventListener("DOMContentLoaded", () => {
           // Delete file button
           const deleteFileBtn = document.createElement("button");
           deleteFileBtn.textContent = "Delete";
-          deleteFileBtn.style.background = "#dc3545";
-          deleteFileBtn.style.color = "#fff";
-          deleteFileBtn.style.border = "none";
-          deleteFileBtn.style.padding = "5px 10px";
-          deleteFileBtn.style.borderRadius = "4px";
-          deleteFileBtn.style.cursor = "pointer";
+          Object.assign(deleteFileBtn.style, {
+            background: "#dc3545",
+            color: "#fff",
+            border: "none",
+            padding: "5px 10px",
+            borderRadius: "4px",
+            cursor: "pointer",
+          });
 
           deleteFileBtn.addEventListener("click", async (e) => {
             e.stopPropagation();
@@ -128,17 +176,17 @@ document.addEventListener("DOMContentLoaded", () => {
             if (!confirmDelete) return;
 
             try {
+              // Must pass ?username= for role check
               const delFileResponse = await fetch(
-                `/api/projects/${projectId}/files/${file.id}`,
-                {
-                  method: "DELETE",
-                }
+                `/api/projects/${projectId}/files/${file.id}?username=${username}`,
+                { method: "DELETE" }
               );
               if (delFileResponse.ok) {
                 alert("File deleted successfully.");
                 fetchProjectFiles(projectId); // Refresh file list
               } else {
-                alert("Failed to delete file.");
+                const errorMsg = await delFileResponse.text();
+                alert("Failed to delete file: " + errorMsg);
               }
             } catch (err) {
               console.error("Error deleting file:", err);
@@ -156,7 +204,36 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   };
 
-  // Create a new project
+  /**
+   * Fetch and display all users assigned to a project (with roles).
+   * This requires an endpoint like /api/projects/{projectId}/users
+   */
+  const fetchProjectUsers = async (projectId) => {
+    try {
+      const response = await fetch(`/api/projects/${projectId}/users`);
+      const users = await response.json();
+
+      userList.innerHTML = ""; // Clear previous list
+
+      if (Array.isArray(users) && users.length > 0) {
+        users.forEach((user) => {
+          const li = document.createElement("li");
+          // e.g. "rahul - PROJECT_OWNER"
+          li.textContent = `${user.username} - ${user.role}`;
+          userList.appendChild(li);
+        });
+      } else {
+        userList.innerHTML = "<li>No users in this project.</li>";
+      }
+    } catch (error) {
+      console.error("Failed to fetch project users:", error);
+      userList.innerHTML = "<li>Failed to load project users.</li>";
+    }
+  };
+
+  /**
+   * Create a new project. After creation, the backend sets the creator as PROJECT_OWNER.
+   */
   createProjectBtn.addEventListener("click", async () => {
     const projectName = prompt("Enter the project name:");
     if (!projectName) return;
@@ -176,7 +253,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  // Upload files to the selected project
+  /**
+   * Upload file, passing username => can check role in backend (OWNER/CONTRIBUTOR).
+   */
   uploadBtn.addEventListener("click", async () => {
     if (!currentProjectId) {
       alert("Please select a project first.");
@@ -185,7 +264,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const files = fileInput.files;
     if (files.length === 0) {
-      alert("Please select files to upload.");
+      alert("Please select a file to upload.");
       return;
     }
 
@@ -193,26 +272,98 @@ document.addEventListener("DOMContentLoaded", () => {
     formData.append("file", files[0]); // For MVP, upload one file at a time
 
     try {
-      const response = await fetch(`/api/projects/${currentProjectId}/upload`, {
-        method: "POST",
-        body: formData,
-      });
+      const response = await fetch(
+        `/api/projects/${currentProjectId}/upload?username=${username}`,
+        {
+          method: "POST",
+          body: formData,
+        }
+      );
       const result = await response.text();
       alert(result);
-      // After uploading, you can auto-fetch or rely on the Show Files button:
+      // Refresh the file list
       fetchProjectFiles(currentProjectId);
     } catch (error) {
       console.error("Failed to upload file:", error);
     }
   });
 
-  // Add event listener to the "Show Files" button
+  /**
+   * "Show Files" button
+   */
   showFilesBtn.addEventListener("click", () => {
     if (!currentProjectId) {
       alert("Please select a project first.");
       return;
     }
     fetchProjectFiles(currentProjectId);
+  });
+
+  // NEW: Add user to the project (PROJECT_OWNER only).
+  // We'll do a simple prompt for userId or username. In a real app, you'd likely show a user dropdown.
+  addUserBtn.addEventListener("click", async () => {
+    if (!currentProjectId) {
+      alert("Please select a project first.");
+      return;
+    }
+
+    // Prompt for the user ID or username (depending on your backend approach).
+    const targetUserId = prompt("Enter the userId you want to add:");
+    if (!targetUserId) return;
+
+    // Prompt for role, or default to "CONTRIBUTOR"
+    const role = prompt(
+      "Enter the role (PROJECT_OWNER, CONTRIBUTOR, REVIEWER)?",
+      "CONTRIBUTOR"
+    );
+    if (!role) return;
+
+    try {
+      const response = await fetch(
+        `/api/projects/${currentProjectId}/assign-role?userId=${targetUserId}&role=${role}&username=${username}`,
+        { method: "POST" }
+      );
+      if (response.ok) {
+        alert(`User ${targetUserId} assigned role: ${role}`);
+        // Refresh user list
+        fetchProjectUsers(currentProjectId);
+      } else {
+        const errorMsg = await response.text();
+        alert("Failed to assign role: " + errorMsg);
+      }
+    } catch (error) {
+      console.error("Error assigning role:", error);
+    }
+  });
+
+  // NEW: Remove user from the project (PROJECT_OWNER only).
+  removeUserBtn.addEventListener("click", async () => {
+    if (!currentProjectId) {
+      alert("Please select a project first.");
+      return;
+    }
+
+    const targetUserId = prompt(
+      "Enter the userId you want to remove from the project:"
+    );
+    if (!targetUserId) return;
+
+    try {
+      const response = await fetch(
+        `/api/projects/${currentProjectId}/revoke-role?userId=${targetUserId}&username=${username}`,
+        { method: "POST" }
+      );
+      if (response.ok) {
+        alert(`User ${targetUserId} removed from project.`);
+        // Refresh user list
+        fetchProjectUsers(currentProjectId);
+      } else {
+        const errorMsg = await response.text();
+        alert("Failed to remove user: " + errorMsg);
+      }
+    } catch (error) {
+      console.error("Error revoking role:", error);
+    }
   });
 
   // Initialize

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -1,9 +1,12 @@
+/**
+ * Handle user login and store the username in sessionStorage.
+ */
 async function handleLogin() {
   const username = document.getElementById("username").value;
   const password = document.getElementById("password").value;
   const errorMessage = document.getElementById("errorMessage");
 
-  // Clear previous error messages
+  // Clear any previous error messages
   errorMessage.textContent = "";
 
   try {
@@ -14,7 +17,7 @@ async function handleLogin() {
     });
 
     if (response.ok) {
-      // Store username in sessionStorage for later use
+      // Store username in sessionStorage for later use (role checks, etc.)
       sessionStorage.setItem("username", username);
 
       // Redirect to the dashboard
@@ -29,25 +32,34 @@ async function handleLogin() {
   }
 }
 
+/**
+ * Simple client-side validation for registration fields.
+ */
 function validateRegistrationFields(username, password, email) {
-  // Add your validation logic, e.g.:
   if (!username || !password || !email) {
     alert("All fields are required.");
     return false;
   }
+  // You could add stronger validation here...
   return true;
 }
 
+/**
+ * Handle user registration and then redirect to login if successful.
+ */
 async function handleRegister() {
   const username = document.getElementById("regUsername").value;
   const password = document.getElementById("regPassword").value;
   const email = document.getElementById("regEmail").value;
-
-  if (!validateRegistrationFields(username, password, email)) {
-    return; // Stop if validation fails
-  }
-
   const errorMessage = document.getElementById("regErrorMessage");
+
+  // Clear any previous error messages
+  errorMessage.textContent = "";
+
+  // Validate fields
+  if (!validateRegistrationFields(username, password, email)) {
+    return;
+  }
 
   try {
     const response = await fetch("/api/users/register", {
@@ -55,7 +67,6 @@ async function handleRegister() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password, email }),
     });
-    console.log(response);
 
     if (response.ok) {
       alert(`User '${username}' registered successfully! Please log in.`);


### PR DESCRIPTION
This PR introduces comprehensive changes to support role-based collaboration in our music platform application. The key enhancements include:
1.	Role Assignments & Enforcement
    o	Added logic so that when a project is created, the creator automatically becomes a PROJECT_OWNER.
    o	PROJECT_OWNER can add or remove users (assign roles) and delete the project.
    o	CONTRIBUTOR can upload/delete files but cannot delete the project or manage users.
    o	REVIEWER has read-only access and cannot modify project data.
2.	User Roles in the Database
    o	We now store roles in a Map<User, String> within each Project, named userRoles.
    o	Added methods to assign and revoke roles via new endpoints (assign-role / revoke-role).
3.	Querying Projects by Role
    o	Introduced a custom JPQL query in ProjectRepository (findProjectsWhereUserHasRoleOrIsOwner) to return all projects in which a given user is either the owner or appears in the userRoles map.
    o	Updated ProjectService.getAllProjectsForUser to use this new query, allowing contributors or reviewers to see projects they participate in.
4.	Frontend Enhancements
    o	dashboard.js:
        	Displays “Add User” / “Remove User” buttons only for PROJECT_OWNER.
        	Allows the owner to search users by username (via /api/users/search) before assigning roles.
        	Ensures role-based capabilities are respected (owners/contributors can delete files, etc.).
    o	The Project Users panel now lists all assigned users with their roles.

